### PR TITLE
Hide advent ad

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -54,7 +54,7 @@ export default defineConfigWithTheme<ThemeOptions>({
             text: 'Verbessere diese Seite',
         },
         banner: {
-            advent: true,
+            advent: false,
         },
     },
     markdown: {


### PR DESCRIPTION
This PR hides the advent ad again.

---

Only merge this PR after the final epilogue on the advent site is public.