### PR TITLE
Handle `mark.js` using vite

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -31,7 +31,7 @@ export default defineConfig<ThemeOptions>({
             }),
         ],
         ssr: {
-            noExternal: ['monaco-editor'],
+            noExternal: ['monaco-editor', 'mark.js'],
         },
         resolve: {
             alias: {


### PR DESCRIPTION
n/t